### PR TITLE
(Re)added filters for custom thumbnail size and masonry options

### DIFF
--- a/frontend/photoswipe-html.php
+++ b/frontend/photoswipe-html.php
@@ -9,7 +9,7 @@ function get_html($post_id, $columns, $args, $attachments = array(), $photoswipe
       $i = 0;
       foreach ($attachments as $aid => $attachment) :
         $i++;
-        $thumb = wp_get_attachment_image_src($aid , 'photoswipe_thumbnails');
+        $thumb = wp_get_attachment_image_src($aid , apply_filters( 'photoswipe_thumbnail_size', 'photoswipe_thumbnails') );
         $full = wp_get_attachment_image_src($aid , 'photoswipe_full');
         $_post = get_post($aid);
         $image_alttext = get_post_meta($aid, '_wp_attachment_image_alt', true);

--- a/frontend/photoswipe-script.php
+++ b/frontend/photoswipe-script.php
@@ -1,21 +1,26 @@
 <?php
 
 function get_script($post_id, $args, $photoswipe_options) {
-  ob_start();
-  ?>
-  <script type='text/javascript'>
-  <?php if($photoswipe_options['use_masonry']) : ?>
-  var psm_gallery_<?= $post_id ?> = new psm_gallery(
-    '#psgal_<?= $post_id ?>',
-    <?= $args['item_count'] ?>,
-    {
-      itemSelector: '.msnry_item',
-      isFitWidth: true
-    }
-  );
-  psm_gallery_<?= $post_id ?>.init();
-  <?php endif; ?>
-  </script>
-  <?php
-  return ob_get_clean();
+	ob_start();
+	?>
+	<script type='text/javascript'>
+	<?php if($photoswipe_options['use_masonry']) : 
+	$masonry_options = "
+		itemSelector: '.msnry_item',
+		isFitWidth: true
+	";
+	$masonry_options = apply_filters( 'photoswipe_masonry_options', $masonry_options );
+	?>
+	var psm_gallery_<?= $post_id ?> = new psm_gallery(
+		'#psgal_<?= $post_id ?>',
+		<?= $args['item_count'] ?>,
+		{
+			<?= $masonry_options ?>
+		}
+	);
+	psm_gallery_<?= $post_id ?>.init();
+	<?php endif; ?>
+	</script>
+	<?php
+	return ob_get_clean();
 }


### PR DESCRIPTION
Included example usage.

Filters were in previous 1.x branch and got lost in 2.x transtion

Original commits were: 548d83f3f5ee18ab23ed96ebab718c5fbdf9adce and f237bbd8b1a5bc85640c843c034ff08c3eb45f1f